### PR TITLE
Allow HTTP header literals to break naming convention

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -278,6 +278,11 @@ module.exports = {
         selector: 'default',
         format: ['camelCase', 'PascalCase', 'snake_case'],
       },
+      {
+        selector: 'objectLiteralProperty',
+        format: null,
+        modifiers: ['requiresQuotes']
+      }
     ],
     '@typescript-eslint/no-base-to-string': 'error',
     '@typescript-eslint/no-confusing-non-null-assertion': 'error',


### PR DESCRIPTION
<img width="388" alt="Screen Shot 2022-05-25 at 15 51 49" src="https://user-images.githubusercontent.com/453297/170189580-31eaafdd-b508-4e17-bc81-bd994436375f.png">

This feature specifically references HTTP headers: https://github.com/typescript-eslint/typescript-eslint/issues/1483

It means we can remove the lint disable for every header literal:

<img width="570" alt="Screen Shot 2022-05-25 at 15 53 18" src="https://user-images.githubusercontent.com/453297/170189732-d941ed67-3db0-446c-a8cd-dbc5631015cc.png">

